### PR TITLE
Update all the things

### DIFF
--- a/installlampwithfirefly.sh
+++ b/installlampwithfirefly.sh
@@ -25,8 +25,13 @@ fi
 # Perform updates
 sudo apt update && sudo apt upgrade -y
 
+# Ensure en_US.UTF-8 locale is installed
+printf "en_US.UTF-8 UTF-8\n"  >>  /etc/locale.gen
+locale-gen
+
 # Install web components
-sudo apt install apache2 mysql-common mariadb-server php8.0 php8.0-common php8.0-bcmath php8.0-intl php8.0-curl php8.0-zip php8.0-gd php8.0-xml php8.0-mbstring php8.0-ldap php8.0-mysql php-mysql curl -y
+sudo apt install apache2 mysql-common mariadb-server php8.2 php8.2-common php8.2-bcmath php8.2-intl php8.2-curl php8.2-zip php8.2-gd php8.2-xml php8.2-mbstring php8.2-ldap php8.2-mysql php-mysql curl -y
+
 echo
 echo "Installing Composer (a friendly php helper that unpacks the php libraries contained within firefly and creates a firefly-iii project)..."
 echo
@@ -46,6 +51,7 @@ sudo chmod -R 775 firefly-iii/storage
 echo
 echo "Unpacking data importer for firefly-iii"
 echo
+
 sudo composer create-project firefly-iii/data-importer --no-dev --prefer-dist data-importer 1.0.2
 sudo chown -R www-data:www-data data-importer
 sudo chmod -R 775 data-importer/storage
@@ -76,7 +82,8 @@ sudo service apache2 restart
 echo
 echo "All done..."
 echo
-echo "You should now be able to visit http://<ipaddress>/firefly-iii/public"
+echo "You should now be able to visit http://<ipaddress>/firefly-iii/public for the Firefly III interface and http://<ipaddress>/data-importer/public for the data importer."
+echo "Some configuration will be needed for the data importer. See https://docs.firefly-iii.org/data-importer/install/configure/"
 echo
 echo "Grab the IP Address from below"
 echo

--- a/installlampwithfirefly.sh
+++ b/installlampwithfirefly.sh
@@ -7,7 +7,7 @@ if grep -q Debian "/etc/os-release" ; then
 	echo "Installing Debian prerequisites"
 	echo
 	sudo apt update
-	sudo apt install -y curl wget gnupg2 ca-certificates lsb-release apt-transport-https
+	sudo apt install -y curl wget gnupg2 ca-certificates lsb-release apt-transport-https unzip
 	wget https://packages.sury.org/php/apt.gpg
 	sudo apt-key add apt.gpg
   echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/php8.list
@@ -38,7 +38,7 @@ echo "If prompted, just hit Enter"
 echo
 echo "Unpacking firefly-iii project"
 echo
-sudo composer create-project grumpydictator/firefly-iii --no-dev --prefer-dist firefly-iii 5.6.16
+sudo composer create-project grumpydictator/firefly-iii --no-dev --prefer-dist firefly-iii 5.7.18
 # This will stop the  white screen issue
 # Changing firefly-iii folder permissions
 sudo chown -R www-data:www-data firefly-iii
@@ -46,7 +46,7 @@ sudo chmod -R 775 firefly-iii/storage
 echo
 echo "Unpacking data importer for firefly-iii"
 echo
-sudo composer create-project firefly-iii/data-importer --no-dev --prefer-dist data-importer 0.9.0
+sudo composer create-project firefly-iii/data-importer --no-dev --prefer-dist data-importer 1.0.2
 sudo chown -R www-data:www-data data-importer
 sudo chmod -R 775 data-importer/storage
 sudo cp firefly-iii/data-importer/.env.example .env


### PR DESCRIPTION
- Fixes #1 by updating the data importer to 1.0.2.
- Updated the release of Firefly III to 5.7.18.
- The latest version of the data importer also requires PHP 8.2, so the script now does that as well (instead of 8.0).
- Installs unzip on Debian systems to avoid an error message (it probably works OK without this).
- Adds the en_US locale to hopefully fix #3. Full Linux installs probably don't need this but the default Proxmox Debian 11 one does.
- Improved the access note.